### PR TITLE
Add more alignment possibilities

### DIFF
--- a/js/gallery-widget-pointer.js
+++ b/js/gallery-widget-pointer.js
@@ -203,6 +203,10 @@
 
         /**
         Sets the correct position to the pointer node.
+        Providing a node still keeps the pointer "stuck" to the pointer box,
+        but it aligns the other coordinate to the center of the provided node.
+        This means that the pointer node always has the fat border of the arrow
+        in touch with the pointer box.
 
         @method _uiSetPointerAlign
         @param {Node} node Node to align the pointer to
@@ -214,6 +218,11 @@
                 box = this._pointerBox,
                 region = box.get('region');
 
+            // Use a region instead of a node for alignment with Plugin.Align
+            // This allows for changing some of the properties to match a
+            // different alignment strategy
+            // This changes the region in the axis opposite to the one
+            // touching the pointer box
             if (node && box !== node) {
                 Y.mix(region, node.get('region'), true,
                     (placement === 'above' || placement === 'below') ?

--- a/js/gallery-widget-pointer.js
+++ b/js/gallery-widget-pointer.js
@@ -89,7 +89,9 @@
             @type Node
             @protected
             **/
-            this._pointerBox = this.get('boundingBox');
+            if (!this._pointerBox) {
+                this._pointerBox = this.get('boundingBox');
+            }
         },
 
         destructor: function () {

--- a/js/gallery-widget-pointer.js
+++ b/js/gallery-widget-pointer.js
@@ -4,59 +4,180 @@
  * @module widget-pointer
  */
     var getCN = Y.ClassNameManager.getClassName,
-        UPARROW = "pointer-up",
-        DOWNARROW = "pointer-down",
-        LEFTARROW = "pointer-left",
-        RIGHTARROW = "pointer-right",
+        UPARROW = "up",
+        DOWNARROW = "down",
+        LEFTARROW = "left",
+        RIGHTARROW = "right",
         POINTER = 'pointer',
         WIDGET = 'widget',
 
         CLASSES = {
             pointer: getCN(WIDGET, POINTER),
-            above: getCN(WIDGET, UPARROW),
-            below: getCN(WIDGET, DOWNARROW),
-            left: getCN(WIDGET, LEFTARROW),
-            right: getCN(WIDGET, RIGHTARROW)
-        },
+            above: getCN(WIDGET, POINTER, UPARROW),
+            below: getCN(WIDGET, POINTER, DOWNARROW),
+            left: getCN(WIDGET, POINTER, LEFTARROW),
+            right: getCN(WIDGET, POINTER, RIGHTARROW)
+        };
 
-        POINTER_TEMPLATE = '<div class="' + CLASSES.pointer + '"></div>',
+    /**
+    Class extension that adds a pointer/arrow element to a widget.
 
-        //HTML5 Data Attributes
-        DATA_PLACEMENT = 'data-placement';
-
+    @class WidgetPointer
+    **/
     function Pointer() {
 
         //  Widget method overlap
-        Y.after(this._renderUIPointer, this, "renderUI");
-        Y.after(this._bindUIPointer, this, "bindUI");
+        Y.after(this._renderUIPointer, this, 'renderUI');
+        Y.after(this._bindUIPointer, this, 'bindUI');
+        Y.after(this._syncUIPointer, this, 'syncUI');
     }
 
     Pointer.ATTRS = {
-        placement : {
-            value: 'above'
+        /**
+        The alignment of the pointer. May be one of 'above', 'below', 'left' or
+        'right', or an object with `node` and `placement` properties.
+
+        @attribute pointerAlign
+        @type String|Object
+        @default 'above'
+        **/
+        pointerAlign: {
+            valueFn: function () {
+                return {
+                    placement: 'above'
+                };
+            },
+            setter: function (value) {
+                return typeof value === 'string' ? {placement: value} : value;
+            }
         }
     };
 
+    /**
+    Table of CSS class names used by this extension. Includes a base 'pointer'
+    class and classes for each pointer direction.
+
+    @property CLASSES
+    @type Object
+    @static
+    **/
+    Pointer.CLASSES = CLASSES;
+
     Pointer.prototype = {
+
+        POINTER_TEMPLATE: '<div class="' + CLASSES.pointer + '"></div>',
+
+        // --- Lifecycle ---
+
+        initializer: function () {
+            /**
+            Pointer element. Usually an element with no width or height that
+            uses a border to look like an arrow.
+
+            @property _pointer
+            @type Node
+            @protected
+            **/
+            this._pointer = Y.Node.create(this.POINTER_TEMPLATE);
+            /**
+            Node to which the pointer sticks to. The pointer is always aligned
+            so that one border touches the border of this box. Defaults to
+            the bounding box of the widget. It can be changed to other elements
+            of the widget.
+
+            @property _pointerBox
+            @type Node
+            @protected
+            **/
+            this._pointerBox = this.get('boundingBox');
+        },
 
         destructor: function () {
             this._pointer.unplug(Y.Plugin.Align);
+            this._pointer = this._pointerBox = null;
         },
 
+        /**
+        Render stage of the lifecycle for the widget's pointer.
+
+        @method _renderUIPointer
+        @protected
+        **/
         _renderUIPointer: function () {
-            var box = this.get('boundingBox');
-            this._pointer = Y.Node.create(POINTER_TEMPLATE);
-            box.prepend(this._pointer);
+            var align = this.get('pointerAlign');
+
+            this.get('boundingBox').prepend(this._pointer);
             this._pointer.plug(Y.Plugin.Align);
-            this.alignPointer(box);
+
+            if (align) {
+                this._setPointerClassnames(align.placement);
+            }
         },
 
+        /**
+        Bind stage of the lifecycle for the widget's pointer.
+
+        @method _bindUIPointer
+        @protected
+        **/
         _bindUIPointer: function () {
-            this.after('placementChange', this._afterPlacementChange);
+            this.after('pointerAlignChange', this._afterPointerAlignChange);
         },
 
+        /**
+        Sync stage of the lifecycle for the widget's pointer.
 
-        _getArrowType : function (placement) {
+        @method _syncUIPointer
+        @protected
+        **/
+        _syncUIPointer: function () {
+            var align = this.get('pointerAlign');
+            this._uiSetPointerAlign(align.node, align.placement);
+        },
+
+        // --- Public API ---
+
+        /**
+        Aligns the pointer to a node and a specific direction. When passing a
+        specific node, the pointer sticks to the border of the widget's bounding
+        box but aligns in the other direction to the center of the provided node.
+
+        This method may be called without attributes to sync the position of the
+        pointer.
+
+        @method alignPointer
+        @param {Node|String} [node] Node or selector to the node to align to.
+                        Defaults to the boundingBox of the widget
+        @param {String} [placement] The orientation of the pointer. May be one
+                        of 'above', 'below', 'left' or 'right'
+        @chainable
+        **/
+        alignPointer: function (node, placement) {
+            if (arguments.length) {
+                node = Y.one(node) || this._pointerBox;
+
+                this.set('pointerAlign', {
+                    node: node,
+                    placement: placement || node.getData('placement')
+                });
+            } else {
+                this._syncUIPointer();
+            }
+
+            return this;
+        },
+
+        // --- Private methods ---
+
+        /**
+        Returns the correct CSS class name for each pointer direction.
+
+        @method _getArrowType
+        @param {String} placement Direction of the pointer
+        @return {String} CSS classname
+        @private
+        **/
+        _getArrowType: function (placement) {
             var arrowClass = '';
 
             switch (placement) {
@@ -80,39 +201,71 @@
             return arrowClass;
         },
 
-        alignPointer : function (node) {
-            
-            var placement = node.getAttribute(DATA_PLACEMENT) || this.get('placement'),
-                box = this.get('boundingBox'),
-                arrowClass = this._getArrowType(placement);
+        /**
+        Sets the correct position to the pointer node.
 
-            this._pointer.set('className', '').addClass(CLASSES.pointer + " " + arrowClass);
+        @method _uiSetPointerAlign
+        @param {Node} node Node to align the pointer to
+        @param {String} placement Direction of the pointer
+        @private
+        **/
+        _uiSetPointerAlign: function (node, placement) {
+            var pointer = this._pointer,
+                box = this._pointerBox,
+                region = box.get('region');
+
+            if (node && box !== node) {
+                Y.mix(region, node.get('region'), true,
+                    (placement === 'above' || placement === 'below') ?
+                    ['left', 'right', 'width'] :
+                    ['top', 'bottom', 'height']
+                );
+            }
 
             switch (placement) {
-                case "below":
-                    this._pointer.align.to(box, "tc", "bc", true);
-                    break;
-                case "right":
-                    this._pointer.align.to(box, "lc", "rc", true);
-                    break;
                 case "above":
-                    this._pointer.align.to(box, "bc", "tc", true);
+                    pointer.align.to(region, "bc", "tc", true);
+                    break;
+                case "below":
+                    pointer.align.to(region, "tc", "bc", true);
                     break;
                 case "left":
-                    this._pointer.align.to(box, "rc", "lc", true);
+                    pointer.align.to(region, "rc", "lc", true);
+                    break;
+                case "right":
+                    pointer.align.to(region, "lc", "rc", true);
                     break;
                 default:
                     Y.log("A correct alignment was not specified. Accepted alignments are 'above', 'below', 'left' and 'right'.");
                     break;
-            }            
+            }
         },
 
-        _afterPlacementChange: function (e) {
-            var arrowClass = this._getArrowType(e.newVal);
-            this._pointer.set('className', '').addClass(CLASSES.pointer + " " + arrowClass);
+        /**
+        Sets the correct classnames to the pointer element.
 
-            if (e.currentTarget instanceof Y.Widget) {
-                this.alignPointer(e.currentTarget.get('boundingBox'));
+        @method _setPointerClassnames
+        @param {String} placement New placement of the pointer
+        @private
+        **/
+        _setPointerClassnames: function (placement) {
+            this._pointer.set('className',
+                CLASSES.pointer + " " + this._getArrowType(placement));
+        },
+
+        /**
+        Syncs the classnames and position of the pointer after its align changes.
+
+        @method _afterPointerAlignChange
+        @param {EventFacade} e Facade for the pointerAlignChange event
+        @private
+        **/
+        _afterPointerAlignChange: function (e) {
+            var align = e.newVal;
+
+            if (align) {
+                this._setPointerClassnames(align.placement);
+                this._uiSetPointerAlign(align.node, align.placement);
             }
         }
         

--- a/tests/manual/index.html
+++ b/tests/manual/index.html
@@ -46,6 +46,11 @@
                 background: white;
                 opacity: 0.7;
             }
+
+            .yui3-customoverlay {
+                background: #000;
+                position: absolute;
+            }
         </style>
     </head>
     
@@ -136,11 +141,12 @@
                     srcNode:"#myContent",
                     // Also set some of the attributes inherited from
                     // the base Widget class.
-                    visible:true,
+                    visible: true,
                     modal: true,
-                    placement: "right",
+                    pointerAlign: "right",
                     centered: true,
-                    width: '50%',
+                    width: 400,
+                    height: 200,
                     render: true
                 });
 
@@ -149,12 +155,12 @@
                 
                 window.setInterval(function () {
                     console.log("changing placement...");
-                    overlay.set('placement', points[i]);
+                    overlay.set('pointerAlign', points[i]);
                     i++;
                     if (i > 3) {
                         i = 0;
                     }
-                }, 300);
+                }, 1000);
                 
             });
         </script>

--- a/tests/manual/popover.html
+++ b/tests/manual/popover.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Popover-like test</title>
+    <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/3.9.0pr3/build/cssnormalize/cssnormalize-min.css">
+    <link rel="stylesheet" type="text/css" href="../../assets/gallery-widget-pointer-core.css">
+    <style>
+a {
+    color: #fff;
+    display: inline-block;
+    padding: 20px;
+    background: gray;
+    margin: 200px;
+}
+.yui3-popover {
+    background: black;
+    position: absolute;
+}
+.yui3-popover-hidden {
+    display: none;
+}
+.beacon {
+    position: absolute;
+    background: red;
+    opacity: 0.5;
+}
+    </style>
+</head>
+<body>
+    <a href="#" data-placement="right">foo</a>
+    <a href="#" data-placement="left">foo</a>
+    <a href="#" data-placement="above">foo</a>
+    <a href="#" data-placement="below">foo</a>
+<script src="http://yui.yahooapis.com/3.9.0/build/yui/yui-debug.js"></script>
+<script>
+    YUI({
+        modules:  {
+            "gallery-widget-pointer": {
+                fullpath: '../../../../build/gallery-widget-pointer/gallery-widget-pointer.js',
+                requires: [
+                    "widget", 
+                    "base-build", 
+                    "align-plugin", 
+                    "classnamemanager"
+                ]
+            }
+        },
+        
+        filter: 'raw',
+    
+    }).use("gallery-widget-pointer", 'base-build',
+        'widget',
+        'widget-position',
+        'widget-position-align',
+        'widget-position-constrain',
+        'widget-stack',
+        'widget-stdmod',
+        'widget-autohide', function(Y) {
+
+        var EXTS = [
+            Y.WidgetPosition,
+            Y.WidgetStdMod,
+            Y.WidgetAutohide,
+            Y.WidgetPositionAlign,
+            Y.WidgetPositionConstrain,
+            Y.WidgetStack,
+            Y.WidgetPointer
+        ];
+    
+        var Popover = Y.Base.create('popover', Y.Widget, EXTS, {
+            bindUI: function () {
+                Y.one('body').delegate('click', this._onDelegateClick, this.get('selector'), this);
+            },
+            _onDelegateClick: function (e) {
+                var points,
+                    node = e.target,
+                    placement = node.getData('placement');
+
+                e.halt();
+
+                switch (placement) {
+                    case 'above':
+                        points = ['bl', 'tl'];
+                        break;
+                    case 'below':
+                        points = ['tl', 'bl'];
+                        break;
+                    case 'left':
+                        points = ['tr', 'tl'];
+                        break;
+                    case 'right':
+                        points = ['tl', 'tr'];
+                        break;
+                }
+                this.show().align(node, points).alignPointer(node, placement);
+            }
+        }, {
+            ATTRS: {
+                selector: {
+                    value: 'a'
+                }
+            }
+        });
+
+        var popover = new Popover({
+            width: 200,
+            height: 100,
+            visible: false,
+            render: true
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR includes a general cleanup and a new approach to aligning the pointer element. This is a list of the changes:
- Expose the `CLASSES` object as a static property
- Rename the `placement` attribute to `pointerAlign` because it's not entirely compatible with the previous one. My understanding is that a class that uses this extension can add a `placement` attribute and change `pointerAlign` based on `placement`
- Add API Docs
- Expose the pointer template as a prototype property
- Use a protected property to store the node that the pointer "sticks" to. This should allow class authors to override it to align the pointer to an element of the widget that is not the bounding box
- `syncUI` syncs the position
- Changing `pointerAlign` repositions the pointer
- `alignPointer` takes two parameters: a node and a placement. The node can be different than the `_pointerBox` to allow for cases like this:

![untitled-1](https://f.cloud.github.com/assets/347002/704607/85f15138-ddc4-11e2-9c77-a5be2dd0f564.png)

Please don't merge it as it is. There are things to discuss like the use of `placement` vs `pointerAlign` and if WidgetPointer should know anything about data attributes (I'm starting to think it shouldn't).

Needs unit and functional tests.
